### PR TITLE
chore: use a github tarball reference so  git is not needed for install

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
   "dependencies": {
     "@types/bluebird": "^3.4.1",
     "@types/node": "^6.0.78",
-    "@types/rethinkdb": "github:types/npm-rethinkdb"
+    "@types/rethinkdb": "https://github.com/types/npm-rethinkdb/tarball/master"
   }
 }


### PR DESCRIPTION
Use case: in a docker build I don't have git installed in the base image so it can't install with a github: reference